### PR TITLE
Safari only renders first frame of Virtual Background Output

### DIFF
--- a/background/virtual-background/demo.js
+++ b/background/virtual-background/demo.js
@@ -1,4 +1,4 @@
- /* eslint-disable */
+/* eslint-disable */
 let setBackground = false;
 let old_id = ""
 
@@ -7,6 +7,21 @@ function getUrlParams(prop) {
   return window.searchParams.get(prop)
 }
 
+
+async function initializeWebcam(){
+  console.log('Initializing initializeWebcam', window.mediaStream)
+  if (window.mediaStream === null || window.mediaStream === undefined || window.mediaStream.active === false) {
+    var webcamStream = await navigator.mediaDevices.getUserMedia(window.constraints || {audio: false, video: true})
+    // {width: 640, height: 360}})
+
+    window.mediaStream = webcamStream;
+  }
+  const video = document.getElementById('video');
+  window.bgFilter && window.bgFilter.changeInput(window.mediaStream)
+  video.srcObject  = window.mediaStream;
+}
+
+/*
 async function initializeWebcam(){
     console.log('Initializing initializeWebcam', window.mediaStream)
     window.mediaStream = null;
@@ -22,30 +37,30 @@ async function initializeWebcam(){
     video.play()
     window.bgFilter && window.bgFilter.changeInput(window.mediaStream)
 }
-
+*/
 
 async function streamWebcam() {
   try{
-      if (!('mediaDevices' in navigator && navigator.mediaDevices.getUserMedia)) {
-          throw "webcam initialization failed"
-      }
-      if(old_id === 'video'){
-        window.bgFilter &&  window.bgFilter.disable()
-        await stopWebcam()
-        old_id=''
-      }else{
-        await initializeWebcam();
-        await enablebackground()
-        updateFPS();
-      }
-    } catch (e) {
-      alert("webcam initialization failed")
+    if (!('mediaDevices' in navigator && navigator.mediaDevices.getUserMedia)) {
+      throw "webcam initialization failed"
     }
+    if(old_id === 'video'){
+      window.bgFilter &&  window.bgFilter.disable()
+      await stopWebcam()
+      old_id=''
+    }else{
+      await initializeWebcam();
+      await enablebackground()
+      updateFPS();
+    }
+  } catch (e) {
+    alert("webcam initialization failed")
   }
+}
 
-  async function stopWebcam(){
-    window.mediaStream.getTracks()[0].stop()
-    window.bgFilter && window.bgFilter.stop()
+async function stopWebcam(){
+  window.mediaStream.getTracks()[0].stop()
+  window.bgFilter && window.bgFilter.stop()
 }
 
 async function enablebackground(type, image) {
@@ -82,9 +97,9 @@ async function disablebackground(){
   setBackground = false;
   const processed = document.getElementById('demo');
   if (window.bgFilter) {
-      window.bgFilter.disable()
-      processed.srcObject = await window.bgFilter.getOutput()
-    }
+    window.bgFilter.disable()
+    processed.srcObject = await window.bgFilter.getOutput()
+  }
 }
 
 function blurbackground(){
@@ -180,7 +195,7 @@ async function changeInputStream(video_id) {
     updateFPS();
 
   } catch (error) {
-      console.log('ERROR in enablebackground', error)
+    console.log('ERROR in enablebackground', error)
   }
 
   // if (!setBackground && window.bgFilter === undefined) {
@@ -210,18 +225,56 @@ async function changeInputStream(video_id) {
 
 window.onload = (event) => {
   console.log(`event`, event)
+  try {
+    setTimeout(() => {
+      // changeInputStream('bg-video-4');
+      // streamWebcam()
+
+      for(var i=0; i < 4; i++){
+        var video = document.getElementById('bg-video-' + (i+1));
+        if(!(video.captureStream || video.mozCaptureStream))  document.getElementById('tab-video-' + (i+1)).style.visibility = "hidden";
+      }
+
+
+    }, 1000);
+  } catch (error) {
+    console.log('ERROR in background load', err)
+  }
+};
+
+
+
+
+
+async function safariClickEnableStream(){
+  document.getElementById('safari-click-enable').style.display = "none";
+  streamWebcam();
+}
+
+window.onload = (event) => {
+  console.log(`event`, event)
     try {
       setTimeout(() => {
       // changeInputStream('bg-video-4');
       // streamWebcam()
 
+        let isSafari = false;
+
         for(var i=0; i < 4; i++){
           var video = document.getElementById('bg-video-' + (i+1));
-          if(!(video.captureStream || video.mozCaptureStream))  document.getElementById('tab-video-' + (i+1)).style.visibility = "hidden";
+          if(!(video.captureStream || video.mozCaptureStream))  {
+            document.getElementById('tab-video-' + (i+1)).style.visibility = "hidden";
+            isSafari = true;
+          }
+
         }
 
+        if(isSafari) {
+          streamWebcam();
+          document.getElementById('safari-click-enable').style.display = "block";
+        }
 
-    }, 1000);
+    }, 200);
   } catch (error) {
     console.log('ERROR in background load', err)
   }

--- a/background/virtual-background/index.html
+++ b/background/virtual-background/index.html
@@ -34,7 +34,7 @@
                     <video class="jss7" id="demo" playsinline autoplay></video>
                     <canvas class="jss31" width="1280" height="853"></canvas>
                     <span class="MuiTypography-root jss32 MuiTypography-caption" id="fps"></span>
-                    <svg class="MuiSvgIcon-root jss14"  height="128" width="128" focusable="false" viewBox="0 0 24 24" style="left: 50%; top: 50%; transform: scale(2.0) translate(-50%, -50%); cursor: pointer;" onclick="streamWebcam()"   aria-hidden="true">
+                    <svg class="MuiSvgIcon-root jss14" id="safari-click-enable" height="128" width="128" focusable="false" viewBox="0 0 24 24" style="left: 50%; top: 50%; transform: scale(2.0) translate(-50%, -50%);  display: none; cursor: pointer;" onclick="safariClickEnableStream()"   aria-hidden="true">
                         <path
                                 d="M10 16.5l6-4.5-6-4.5v9zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z">
                         </path>

--- a/background/virtual-background/index.html
+++ b/background/virtual-background/index.html
@@ -34,6 +34,11 @@
                     <video class="jss7" id="demo" playsinline autoplay></video>
                     <canvas class="jss31" width="1280" height="853"></canvas>
                     <span class="MuiTypography-root jss32 MuiTypography-caption" id="fps"></span>
+                    <svg class="MuiSvgIcon-root jss14"  height="128" width="128" focusable="false" viewBox="0 0 24 24" style="left: 50%; top: 50%; transform: scale(2.0) translate(-50%, -50%); cursor: pointer;" onclick="streamWebcam()"   aria-hidden="true">
+                        <path
+                                d="M10 16.5l6-4.5-6-4.5v9zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z">
+                        </path>
+                    </svg>
                 </div>
             </div>
             <div class="MuiPaper-root MuiCard-root jss8 MuiPaper-elevation1 MuiPaper-rounded">


### PR DESCRIPTION
Story details: https://app.clubhouse.io/vectorly/story/4850

Test on Safari

Before:
https://files.vectorly.io/demo/virtual-background-safari-debug/16/index.html

After:
https://files.vectorly.io/demo/virtual-background-safari-debug/29/index.html

I think that Safari needs a user click for some permissions, to enable the webcam to stream properly. This isn't an issue in the html5 demo, because you have to click multiple times anyway

The workaround here: If it's safari, show a play button on the playback stream. When the user clicks the playback stream, it should load and start playing normally



